### PR TITLE
Fixed "expires_in" parsing for AzureAD

### DIFF
--- a/simple_auth/lib/src/oauth/oauthResponse.dart
+++ b/simple_auth/lib/src/oauth/oauthResponse.dart
@@ -27,7 +27,7 @@ class OAuthResponse implements JsonSerializable {
 
   factory OAuthResponse.fromJson(Map<String, dynamic> json) => OAuthResponse(
       json["token_type"],
-      json["expires_in"],
+      int.parse(json["expires_in"]),
       json["refresh_token"],
       json["access_token"],
       json["id_token"],


### PR DESCRIPTION
Azure returns "expires_in" as a string which throws an exception when converting the JSON to an OAuthResponse.

I'm uncertain whether this will affect the other providers. An alternative would be to change expiresIn on OAuthResponse from an int to a String like all the other members.