### PR TITLE
Expire_IN OAuth Response Attribute to be optional as per OAuth specification

### DIFF
--- a/simple_auth/lib/src/oauth/oauthResponse.dart
+++ b/simple_auth/lib/src/oauth/oauthResponse.dart
@@ -27,9 +27,11 @@ class OAuthResponse implements JsonSerializable {
 
   factory OAuthResponse.fromJson(Map<String, dynamic> json) => OAuthResponse(
       json["token_type"],
-      json["expires_in"] is int
-          ? json["expires_in"]
-          : int.parse(json["expires_in"]),
+      json.containsKey("expires_in")
+          ? json["expires_in"] is int
+              ? json["expires_in"]
+              : int.parse(json["expires_in"])
+          : 3600, 
       json["refresh_token"],
       json["access_token"],
       json["id_token"],


### PR DESCRIPTION
I have been using this great library in conjunction with Salesforce.

Suggesting this adjustment to the Response object to deal with the Optional (although recommended) Attribute of Expire_In - with a default timeout of 3600?

This makes the oAuth library compatible with Salesforce oAuth