### PR TITLE
Fixed an issue with iOS9/10

### DIFF
--- a/simple_auth_flutter/ios/Classes/SFSafariAuthenticator.m
+++ b/simple_auth_flutter/ios/Classes/SFSafariAuthenticator.m
@@ -35,6 +35,8 @@
         NSLog(@"presenting the authenticator");
         UIWindow *window = UIApplication.sharedApplication.keyWindow;
         UIViewController *root = window.rootViewController;
+        [SFSafariAuthenticator.authenticators setObject:authenticator  forKey:authenticator.redirectUrl.scheme];
+
         if(root != nil)
         {
             UIViewController *current = root;

--- a/simple_auth_flutter/ios/Classes/SimpleAuthFlutterPlugin.m
+++ b/simple_auth_flutter/ios/Classes/SimpleAuthFlutterPlugin.m
@@ -36,8 +36,10 @@
         [authenticators setObject:authenticator  forKey:authenticator.identifier];
         if(authenticator.useEmbeddedBrowser)
             [WebAuthenticatorWindow presentAuthenticator: authenticator];
-        else
+        else {
             [SFSafariAuthenticator presentAuthenticator:authenticator];
+            [SFSafariAuthenticator.authenticators setObject:authenticator  forKey:authenticator.redirectUrl.scheme];
+        }
         result(@"success");
         return;
     }

--- a/simple_auth_flutter/ios/Classes/SimpleAuthFlutterPlugin.m
+++ b/simple_auth_flutter/ios/Classes/SimpleAuthFlutterPlugin.m
@@ -36,10 +36,8 @@
         [authenticators setObject:authenticator  forKey:authenticator.identifier];
         if(authenticator.useEmbeddedBrowser)
             [WebAuthenticatorWindow presentAuthenticator: authenticator];
-        else {
+        else
             [SFSafariAuthenticator presentAuthenticator:authenticator];
-            [SFSafariAuthenticator.authenticators setObject:authenticator  forKey:authenticator.redirectUrl.scheme];
-        }
         result(@"success");
         return;
     }


### PR DESCRIPTION
Authenticator is never added to the map, making auth fail on 9/10 for me at least. 

Adding this solved the bug on my end, could be I was just missing something, but if not, this should be a welcome one for people also having to work with legacy devices.