### PR TITLE
set scope in OAuthAccount object

### DIFF
--- a/simple_auth/lib/src/providers/dropbox.dart
+++ b/simple_auth/lib/src/providers/dropbox.dart
@@ -32,6 +32,7 @@ class DropboxApi extends OAuthApi {
     return OAuthAccount(identifier,
         created: DateTime.now().toUtc(),
         expiresIn: -1,
+        scope: authenticator.scope,
         refreshToken: auth.token,
         tokenType: auth.tokenType,
         token: auth.token);


### PR DESCRIPTION
Set a scope so it gets set to List<String> by default instead of null.