### PR TITLE
Clear cookies before launching webview for authentication

### DIFF
--- a/simple_auth_flutter/android/src/main/java/clancey/simpleauth/simpleauthflutter/WebAuthenticatorActivity.java
+++ b/simple_auth_flutter/android/src/main/java/clancey/simpleauth/simpleauthflutter/WebAuthenticatorActivity.java
@@ -6,6 +6,7 @@ import android.content.Intent;
 import android.graphics.Bitmap;
 import android.os.Bundle;
 import android.os.PersistableBundle;
+import android.webkit.CookieManager;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
@@ -60,6 +61,8 @@ public class WebAuthenticatorActivity extends Activity {
         webview = new WebView(this);
 
         WebSettings settings = webview.getSettings();
+        CookieManager.getInstance().removeAllCookies(null);
+        CookieManager.getInstance().flush();
         if(UserAgent != null && !UserAgent.isEmpty())
         {
             settings.setUserAgentString(UserAgent);


### PR DESCRIPTION
Performing Azure OAuth authentication with client secret key, caches the authorization code in cookie manager. Hence even after clearing local auth storage data using AzureADApi.logOut() isn't completely log out the user. Launching WebAuthenticatorActivity after logout() is reusing existing auth code from cookie manager instead of authenticating again.