### PR TITLE
fix(simple_auth_flutter_example): parameter order

### DIFF
--- a/simple_auth_flutter_example/lib/api_definitions/azureAdTestApi.dart
+++ b/simple_auth_flutter_example/lib/api_definitions/azureAdTestApi.dart
@@ -3,7 +3,14 @@ import "package:http/http.dart" as http;
 
 part 'azureAdTestApi.simple_auth.dart';
 
-@AzureADApiDeclaration("AzureAdTestApi","resource","client_id","redirecturl",azureTennant: "azureTennant",clientSecret: "client_secret")
+@AzureADApiDeclaration(
+  "AzureAdTestApi",
+  "client_id",
+  "resource",
+  "redirecturl",
+  azureTennant: "azureTennant",
+  clientSecret: "client_secret"
+)
 abstract class AzureADDefinition {
 
 }

--- a/simple_auth_flutter_example/lib/api_definitions/azureAdTestApi.simple_auth.dart
+++ b/simple_auth_flutter_example/lib/api_definitions/azureAdTestApi.simple_auth.dart
@@ -8,12 +8,12 @@ part of 'azureAdTestApi.dart';
 
 class AzureAdTestApi extends AzureADApi implements AzureADDefinition {
   AzureAdTestApi(String identifier,
-      {String clientId: 'resource',
+      {String clientId: 'client_id',
       String authorizationUrl:
           'https://login.microsoftonline.com/azureTennant/oauth2/authorize',
       String tokenUrl:
           'https://login.microsoftonline.com/azureTennant/oauth2/token',
-      String resource: 'client_id',
+      String resource: 'resource',
       String redirectUrl: 'redirecturl',
       String clientSecret: 'client_secret',
       List<String> scopes,


### PR DESCRIPTION
I believe the `azureAdTestApi.dart` [example](https://github.com/Clancey/simple_auth/blob/master/simple_auth_flutter_example/lib/api_definitions/azureAdTestApi.dart) is wrong/out-of-date. It orders the params:
```
"AzureAdTestApi","resource","client_id","redirecturl"
```
When it should be (defined [here](https://github.com/Clancey/simple_auth/blob/00e51a4f27849c4b720a6b734930f2d35664cc05/simple_auth/lib/src/annotations.dart#L193)):
```
name, this.clientId, this.resource, this.redirectUrl
```