### PR TITLE
1 support sign on without sso (no SFAuthenticationSession)

### DIFF
--- a/simple_auth/lib/src/api/webAuthenticator.dart
+++ b/simple_auth/lib/src/api/webAuthenticator.dart
@@ -12,6 +12,7 @@ abstract class WebAuthenticator extends Authenticator {
   String _redirectUrl;
   String get redirectUrl => _redirectUrl;
   bool useEmbeddedBrowser = false;
+  bool useSSO = true;
   set redirectUrl(String value) {
     this._redirectUrl = value;
     if (value?.isNotEmpty ?? false)

--- a/simple_auth/lib/src/providers/google.dart
+++ b/simple_auth/lib/src/providers/google.dart
@@ -53,6 +53,8 @@ class GoogleAuthenticator extends OAuthAuthenticator {
             redirectUrl) {
     this.scope = scopes;
     useEmbeddedBrowser = false;
+    // Set this to false to remove Apple's user consent dialog
+    useSSO = true;
     usePkce = true;
   }
 

--- a/simple_auth_flutter/README.md
+++ b/simple_auth_flutter/README.md
@@ -82,6 +82,7 @@ on iOS you need the following in your app delegate.
 ```
 
 For iOS 11 and higher, you don't need to do anything else. On older iOS versions the following is required in the info.plist
+Note, these lines are required, if you want to avoid Apples mandatory user consent dialog - **"this allows the app and website to share information about you"**. This can be achieved by setting `WebAuthenticator.useSSO = false;` which will not use SFAuthenticationSession.  
 
 ```xml
 	<key>CFBundleURLTypes</key>

--- a/simple_auth_flutter/ios/Classes/SFSafariAuthenticator.m
+++ b/simple_auth_flutter/ios/Classes/SFSafariAuthenticator.m
@@ -56,7 +56,7 @@ SFSafariViewController *controller;
 -(void) beginAuthentication:(WebAuthenticator *)authenticator viewController:(UIViewController *)viewController{
     @try{
         NSString *scheme = authenticator.redirectUrl.scheme;
-        if(@available(iOS 11.0, *))
+        if(@available(iOS 11.0, *) && authenticator.useSSO)
         {
             session =  [[SFAuthenticationSession alloc] initWithURL:authenticator.initialUrl callbackURLScheme:scheme completionHandler:^(NSURL * _Nullable callbackURL, NSError * _Nullable error) {
                 if(error == nil)

--- a/simple_auth_flutter/ios/Classes/WebAuthenticator.h
+++ b/simple_auth_flutter/ios/Classes/WebAuthenticator.h
@@ -17,6 +17,7 @@
 @property BOOL allowsCancel;
 @property BOOL isCompleted;
 @property BOOL useEmbeddedBrowser;
+@property BOOL useSSO;
 @property FlutterEventSink eventSink;
 -(void)checkUrl:(NSURL *)url forceComplete:(BOOL)force;
 -(void)foundToken;

--- a/simple_auth_flutter/ios/Classes/WebAuthenticator.m
+++ b/simple_auth_flutter/ios/Classes/WebAuthenticator.m
@@ -18,6 +18,7 @@
         self.identifier = [data_ valueForKey:@"identifier"];
         self.allowsCancel = [[data_ valueForKey:@"allowsCancel"] boolValue];
         self.useEmbeddedBrowser =[[data_ valueForKey:@"useEmbeddedBrowser"] boolValue];
+        self.useSSO =[[data_ valueForKey:@"useSSO"] boolValue];
         self.initialUrl = [NSURL URLWithString:[data_ valueForKey:@"initialUrl"]];
         self.redirectUrl = [NSURL URLWithString:[data_ valueForKey:@"redirectUrl"]];
         self.title = [data_ valueForKey:@"title"];

--- a/simple_auth_flutter/lib/simple_auth_flutter.dart
+++ b/simple_auth_flutter/lib/simple_auth_flutter.dart
@@ -36,7 +36,8 @@ class SimpleAuthFlutter implements simpleAuth.AuthStorage {
       "title": authenticator.title,
       "allowsCancel": authenticator.allowsCancel.toString(),
       "redirectUrl": authenticator.redirectUrl,
-      "useEmbeddedBrowser": authenticator.useEmbeddedBrowser.toString()
+      "useEmbeddedBrowser": authenticator.useEmbeddedBrowser.toString(),
+      "useSSO": authenticator.useSSO.toString()
     });
     if (url == "cancel") {
       authenticator.cancel();


### PR DESCRIPTION
In order to measure and reduce **app abandonment rates** caused by Apples forced dialog 

- **"this allows the app and website to share information about you"**

add an optional parameter to sign on without using SFAuthenticationSession.  
