### PR TITLE
fix httpClient.post argument for http 0.13.0

### DIFF
--- a/simple_auth/lib/src/providers/keycloak.dart
+++ b/simple_auth/lib/src/providers/keycloak.dart
@@ -52,7 +52,7 @@ class KeycloakApi extends OAuthApi {
     if (account == null) throw new Exception("Invalid Account");
 
     var postData = await getRefreshTokenPostData(account);
-    var resp = await httpClient.post("${this.baseUrl}/auth/realms/${this.realm}/protocol/openid-connect/logout",
+    var resp = await httpClient.post(Uri.parse("${this.baseUrl}/auth/realms/${this.realm}/protocol/openid-connect/logout"),
         headers: {
           "Accept": "application/json",
           "Content-Type": "application/x-www-form-urlencoded"


### PR DESCRIPTION
As I point out here: https://github.com/Clancey/simple_auth/issues/152, the String argument does not match the definition used with http 0.13.0.
It should be of type Uri.